### PR TITLE
US1066076: Add 'visibleByDefault' field to entityTypeColumn schema

### DIFF
--- a/src/main/resources/swagger.api/schemas/entityTypeColumn.json
+++ b/src/main/resources/swagger.api/schemas/entityTypeColumn.json
@@ -16,6 +16,10 @@
       "description": "The identifier used for a localized label/name for this column.",
       "type": "string"
     },
+    "visibleByDefault": {
+      "description": "Indicates if the column should be shown by default when the entity is viewed.",
+      "type": "boolean"
+    },
     "values": {
       "type": "array",
       "items": {


### PR DESCRIPTION
## Purpose
Add "visibleByDefault" boolean property to entity type's column definition schema. This new property will indicate if the column has to be shown by default when the entity is displayed to a user (for example, via the viewer component)

## Approach
Add the property to "enitityTypeColumn.json" file

#### TODOS and Open Questions
None

## Learning
N/A