### PR TITLE
US1067196: Make data types less verbose by removing the word 'EntityData'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@
               <generateApiTests>true</generateApiTests>
               <generateApiDocumentation>true</generateApiDocumentation>
               <generateModels>true</generateModels>
-              <modelsToGenerate>entityDataType,arrayEntityDataType,dateEntityDataType,entityTypeRelation,objectEntityDataType,entityTypeColumn,enumEntityDataType,booleanEntityDataType,entityType,integerEntityDataType,openUUIDEntityDataType,stringEntityDataType,numberEntityDataType,rangedUUIDEntityDataType,valueWithLabel</modelsToGenerate>
+              <modelsToGenerate>entityDataType,arrayType,dateType,entityTypeRelation,objectType,entityTypeColumn,enumType,booleanType,entityType,integerType,openUUIDType,stringType,numberType,rangedUUIDType,valueWithLabel</modelsToGenerate>
               <generateModelTests>false</generateModelTests>
               <generateModelDocumentation>true</generateModelDocumentation>
               <generateSupportingFiles>true</generateSupportingFiles>

--- a/src/main/resources/swagger.api/queryTool.yaml
+++ b/src/main/resources/swagger.api/queryTool.yaml
@@ -26,23 +26,23 @@ components:
       $ref: schemas/entityType.json#/EntityType
     entityDataType:
       $ref: schemas/entityDataType.json#/EntityDataType
-    stringEntityDataType:
-      $ref: schemas/entityDataType.json#/StringEntityDataType
-    rangedUUIDEntityDataType:
-      $ref: schemas/entityDataType.json#/RangedUUIDEntityDataType
-    openUUIDEntityDataType:
-      $ref: schemas/entityDataType.json#/OpenUUIDEntityDataType
-    numberEntityDataType:
-      $ref: schemas/entityDataType.json#/NumberEntityDataType
-    integerEntityDataType:
-      $ref: schemas/entityDataType.json#/IntegerEntityDataType
-    booleanEntityDataType:
-      $ref: schemas/entityDataType.json#/BooleanEntityDataType
-    dateEntityDataType:
-      $ref: schemas/entityDataType.json#/DateEntityDataType
-    enumEntityDataType:
-      $ref: schemas/entityDataType.json#/EnumEntityDataType
-    objectEntityDataType:
-      $ref: schemas/entityDataType.json#/ObjectEntityDataType
-    arrayEntityDataType:
-      $ref: schemas/entityDataType.json#/ArrayEntityDataType
+    stringType:
+      $ref: schemas/entityDataType.json#/StringType
+    rangedUUIDType:
+      $ref: schemas/entityDataType.json#/RangedUUIDType
+    openUUIDType:
+      $ref: schemas/entityDataType.json#/OpenUUIDType
+    numberType:
+      $ref: schemas/entityDataType.json#/NumberType
+    integerType:
+      $ref: schemas/entityDataType.json#/IntegerType
+    booleanType:
+      $ref: schemas/entityDataType.json#/BooleanType
+    dateType:
+      $ref: schemas/entityDataType.json#/DateType
+    enumType:
+      $ref: schemas/entityDataType.json#/EnumType
+    objectType:
+      $ref: schemas/entityDataType.json#/ObjectType
+    arrayType:
+      $ref: schemas/entityDataType.json#/ArrayType

--- a/src/main/resources/swagger.api/schemas/entityDataType.json
+++ b/src/main/resources/swagger.api/schemas/entityDataType.json
@@ -17,7 +17,7 @@
       "propertyName": "dataType"
     }
   },
-  "StringEntityDataType": {
+  "StringType": {
     "description": "Entity field type defined in https://issues.folio.org/browse/UIPQB-5",
     "allOf": [
       {
@@ -25,7 +25,7 @@
       }
     ]
   },
-  "RangedUUIDEntityDataType": {
+  "RangedUUIDType": {
     "description": "Entity field type defined in https://issues.folio.org/browse/UIPQB-2, https://issues.folio.org/browse/UIPQB-3",
     "allOf": [
       {
@@ -33,7 +33,7 @@
       }
     ]
   },
-  "OpenUUIDEntityDataType": {
+  "OpenUUIDType": {
     "description": "Entity field type defined in https://issues.folio.org/browse/UIPQB-4",
     "allOf": [
       {
@@ -41,14 +41,14 @@
       }
     ]
   },
-  "NumberEntityDataType": {
+  "NumberType": {
     "allOf": [
       {
         "$ref": "entityDataType.json#/EntityDataType"
       }
     ]
   },
-  "IntegerEntityDataType": {
+  "IntegerType": {
     "description": "Entity field type defined in https://issues.folio.org/browse/UIPQB-7",
     "allOf": [
       {
@@ -56,7 +56,7 @@
       }
     ]
   },
-  "DateEntityDataType": {
+  "DateType": {
     "description": "Entity field type defined in https://issues.folio.org/browse/UIPQB-9",
     "allOf": [
       {
@@ -64,7 +64,7 @@
       }
     ]
   },
-  "BooleanEntityDataType": {
+  "BooleanType": {
     "description": "Entity field type defined in https://issues.folio.org/browse/UIPQB-8",
     "allOf": [
       {
@@ -72,7 +72,7 @@
       }
     ]
   },
-  "EnumEntityDataType": {
+  "EnumType": {
     "description": "Entity field type defined in https://issues.folio.org/browse/UIPQB-11",
     "allOf": [
       {
@@ -80,7 +80,7 @@
       }
     ]
   },
-  "ObjectEntityDataTypeContainer": {
+  "ObjectTypeContainer": {
     "type": "object",
     "properties": {
       "objectDefinition": {
@@ -92,18 +92,18 @@
       "objectDefinition"
     ]
   },
-  "ObjectEntityDataType": {
+  "ObjectType": {
     "description": "Entity field type defined in https://issues.folio.org/browse/UIPQB-10",
     "allOf": [
       {
         "$ref": "entityDataType.json#/EntityDataType"
       },
       {
-        "$ref": "#/ObjectEntityDataTypeContainer"
+        "$ref": "#/ObjectTypeContainer"
       }
     ]
   },
-  "ArrayEntityDataTypeContainer": {
+  "ArrayTypeContainer": {
     "type": "object",
     "properties": {
       "itemDataType": {
@@ -115,14 +115,14 @@
       "itemDataType"
     ]
   },
-  "ArrayEntityDataType": {
+  "ArrayType": {
     "description": "Entity field type defined in https://issues.folio.org/browse/UIPQB-6",
     "allOf": [
       {
         "$ref": "entityDataType.json#/EntityDataType"
       },
       {
-        "$ref": "#/ArrayEntityDataTypeContainer"
+        "$ref": "#/ArrayTypeContainer"
       }
     ]
   }


### PR DESCRIPTION


## Purpose
The data type names for column definitions were very long, having the format 'XYZEntityDataType" (example: StringEntityDataType). Purpose of this change is to shorten the data type names by removing the word "EntityData" from the data type name. For example shorten "StringEntityDataType" to "StringType"
Here is an example definition based on the updated schema

`
{
            "id": "123",
            "name": "item_details",
            "columns": [
                {
                    "name": "pk-string-col",
                    "labelAlias": "pk-string-col-label",
                    "dataType": {
                        "dataType": "stringType"
                    }
                },
                {
                    "name": "pk-int-col1",
                    "labelAlias": "pk-int-col-label",
                    "dataType": {
                        "dataType": "integerType"
                    }
                }
            ]
        }
`

## Approach
Made the changes as explained in the "Purpose" section. Executed "mvn compile" and ensured that DTO classes are created successfully. Deserialized a sample definition to the DTO class and ensured that deserialization is done correctly. 

<img width="1273" alt="Screen Shot 2023-01-20 at 2 24 35 PM" src="https://user-images.githubusercontent.com/121239864/213788228-962ad44f-0093-435b-8994-2be8361f04b1.png">


#### TODOS and Open Questions
None

## Learning
N/A
