### PR TITLE
US1074823: Enhance entityType schema by adding 'defaultSort' meta-data

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@
               <generateApiTests>true</generateApiTests>
               <generateApiDocumentation>true</generateApiDocumentation>
               <generateModels>true</generateModels>
-              <modelsToGenerate>entityDataType,arrayType,dateType,entityTypeRelation,objectType,entityTypeColumn,enumType,booleanType,entityType,integerType,openUUIDType,stringType,numberType,rangedUUIDType,valueWithLabel</modelsToGenerate>
+              <modelsToGenerate>entityDataType,arrayType,dateType,entityTypeRelation,objectType,entityTypeColumn,enumType,booleanType,entityType,integerType,openUUIDType,stringType,numberType,rangedUUIDType,valueWithLabel,entityTypeDefaultSort</modelsToGenerate>
               <generateModelTests>false</generateModelTests>
               <generateModelDocumentation>true</generateModelDocumentation>
               <generateSupportingFiles>true</generateSupportingFiles>

--- a/src/main/resources/swagger.api/queryTool.yaml
+++ b/src/main/resources/swagger.api/queryTool.yaml
@@ -46,3 +46,5 @@ components:
       $ref: schemas/entityDataType.json#/ObjectType
     arrayType:
       $ref: schemas/entityDataType.json#/ArrayType
+    entityTypeDefaultSort:
+      $ref: schemas/entityTypeDefaultSort.json

--- a/src/main/resources/swagger.api/schemas/entityType.json
+++ b/src/main/resources/swagger.api/schemas/entityType.json
@@ -23,6 +23,13 @@
           "type": "object",
           "$ref": "entityTypeColumn.json"
         }
+      },
+      "defaultSort": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "$ref": "entityTypeDefaultSort.json"
+        }
       }
     },
     "required": [

--- a/src/main/resources/swagger.api/schemas/entityTypeDefaultSort.json
+++ b/src/main/resources/swagger.api/schemas/entityTypeDefaultSort.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Default sort criteria for an entity type",
+  "description": "A definition of default sort criteria for an entity type",
+  "type": "object",
+  "properties": {
+    "columnName": {
+      "description": "Name of the column using which entity type has to be sorted",
+      "type": "string"
+    },
+    "direction": {
+      "description": "Direction of the sort (Ascending or Descending)",
+      "type": "string",
+      "enum": ["ASC", "DESC"]
+    }
+  },
+  "required": [
+    "columnName", "direction"
+  ]
+}


### PR DESCRIPTION
## Purpose
Each entity type should have a default sort criteria. The default sort criteria specifies the columns & the direction based on which the records in an entity type will be sorted by default. 

Purpose of this pull request is to update the "entityType.json" schema by including the "defaultSort" configuration.

## Approach
Update the "entityType.json" schema by including the "defaultSort" configuration.

#### TODOS and Open Questions
None

## Learning
N/A
