### PR TITLE
US1084584: Add GET recordsCount & columnValue API; Enhance column Defintion with new fields

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@
               <generateApiTests>true</generateApiTests>
               <generateApiDocumentation>true</generateApiDocumentation>
               <generateModels>true</generateModels>
-              <modelsToGenerate>entityDataType,arrayType,dateType,entityTypeRelation,objectType,entityTypeColumn,enumType,booleanType,entityType,integerType,openUUIDType,stringType,numberType,rangedUUIDType,valueWithLabel,entityTypeDefaultSort,errors,error,parameters,parameter,resultsetPage,queryResult</modelsToGenerate>
+              <modelsToGenerate>entityDataType,arrayType,dateType,entityTypeRelation,objectType,entityTypeColumn,enumType,booleanType,entityType,integerType,openUUIDType,stringType,numberType,rangedUUIDType,valueWithLabel,entityTypeDefaultSort,errors,error,parameters,parameter,resultsetPage,queryResult,sourceColumn,totalRecords,columnValues,columnValueGetter</modelsToGenerate>
               <generateModelTests>false</generateModelTests>
               <generateModelDocumentation>true</generateModelDocumentation>
               <generateSupportingFiles>true</generateSupportingFiles>

--- a/src/main/resources/swagger.api/examples/columnValues.sample
+++ b/src/main/resources/swagger.api/examples/columnValues.sample
@@ -1,0 +1,20 @@
+{
+  "content": [
+    {
+      "label": "book",
+      "value": "025ba2c5-5e96-4667-a677-8186463aee69"
+    },
+    {
+      "label": "dvd",
+      "value": "b3d29557-c74d-403d-a279-a2ef6b3a80f6"
+    },
+    {
+      "label": "audio -- audiocassette",
+      "value": "13fbfe78-9cd4-4edd-817b-8a92292466f3"
+    },
+    {
+      "label": "video -- videotape reel",
+      "value": "c41b1127-afca-4888-8ef1-8b06e25f7f91"
+    }
+  ]
+}

--- a/src/main/resources/swagger.api/examples/totalRecords.sample
+++ b/src/main/resources/swagger.api/examples/totalRecords.sample
@@ -1,0 +1,3 @@
+{
+  "totalRecords": 1000
+}

--- a/src/main/resources/swagger.api/queryTool.yaml
+++ b/src/main/resources/swagger.api/queryTool.yaml
@@ -26,6 +26,28 @@ paths:
         '500':
           $ref: '#/components/responses/internalServerErrorResponse'
 
+  /entity-types/{entityTypeId}/columns/{columnName}/values:
+    get:
+      operationId: getColumnValues
+      description: Get values of an entity type column.
+      tags:
+        - entity-types
+      parameters:
+        - $ref: '#/components/parameters/entityTypeId'
+        - $ref: '#/components/parameters/columnName'
+      responses:
+        '200':
+          description: 'Values of an entity type column'
+          content:
+            application/json:
+              example: examples/columnValues.sample
+              schema:
+                $ref: '#/components/schemas/columnValues'
+        '400':
+          $ref: '#/components/responses/badRequestResponse'
+        '500':
+          $ref: '#/components/responses/internalServerErrorResponse'
+
   /resultsets/{resultsetId}:
     get:
       operationId: getResultSetById
@@ -57,6 +79,7 @@ paths:
         - fqlQuery
       parameters:
         - $ref: '#/components/parameters/fqlQuery'
+        - $ref: '#/components/parameters/entityTypeIdQueryParam'
       responses:
         '200':
           description: 'The test query result'
@@ -76,6 +99,7 @@ paths:
         - fqlQuery
       parameters:
         - $ref: '#/components/parameters/fqlQuery'
+        - $ref: '#/components/parameters/entityTypeIdQueryParam'
       responses:
         '200':
           description: 'The resultset identifier for the query run'
@@ -84,6 +108,27 @@ paths:
               example: examples/queryResult.sample
               schema:
                 $ref: '#/components/schemas/queryResult'
+        '400':
+          $ref: '#/components/responses/badRequestResponse'
+        '500':
+          $ref: '#/components/responses/internalServerErrorResponse'
+  /recordsCount:
+    get:
+      operationId: getRecordsCount
+      description: Gets the records count that matches an FQL query
+      tags:
+        - fqlQuery
+      parameters:
+        - $ref: '#/components/parameters/fqlQuery'
+        - $ref: '#/components/parameters/entityTypeIdQueryParam'
+      responses:
+        '200':
+          description: 'Total records that matches the FQL query'
+          content:
+            application/json:
+              example: examples/totalRecords.sample
+              schema:
+                $ref: '#/components/schemas/totalRecords'
         '400':
           $ref: '#/components/responses/badRequestResponse'
         '500':
@@ -98,6 +143,20 @@ components:
       description: UUID of the entity type
       schema:
         $ref: '#/components/schemas/UUID'
+    entityTypeIdQueryParam:
+      name: entityTypeId
+      in: query
+      required: true
+      description: UUID of the entity type
+      schema:
+        $ref: '#/components/schemas/UUID'
+    columnName:
+      name: columnName
+      in: path
+      required: true
+      description: Name of an entity type column
+      schema:
+        type: string
     resultsetId:
       name: resultsetId
       in: path
@@ -175,6 +234,10 @@ components:
       $ref: schemas/resultset.json#/ResultsetPage
     queryResult:
       $ref: schemas/resultset.json#/QueryResult
+    totalRecords:
+      $ref: schemas/resultset.json#/TotalRecords
+    columnValues:
+      $ref: schemas/columnValues.json
 
   responses:
     badRequestResponse:

--- a/src/main/resources/swagger.api/schemas/columnValueGetter.json
+++ b/src/main/resources/swagger.api/schemas/columnValueGetter.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Configuration for fetching data of a column from the underlying datasource",
+  "description": "Configuration for fetching data of a column from the underlying datasource",
+  "type": "object",
+  "properties": {
+    "type": {
+      "description": "Type of the data extraction strategy to be applied",
+      "type": "string",
+      "enum": ["rmb_jsonb"]
+    },
+    "param": {
+      "description": "Parameter of the data extraction strategy. Value of this field is specific to the extraction strategy used.",
+      "type": "string"
+    }
+  },
+  "required": [
+    "content"
+  ]
+}

--- a/src/main/resources/swagger.api/schemas/columnValues.json
+++ b/src/main/resources/swagger.api/schemas/columnValues.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Label (if available) & values of an entity type column",
+  "description": "Label (if available) & values of an entity type column",
+  "type": "object",
+  "properties": {
+    "content": {
+      "description": "Array of label & value pair",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "$ref": "valueWithLabel.json"
+      }
+    }
+  },
+  "required": [
+    "content"
+  ]
+}

--- a/src/main/resources/swagger.api/schemas/entityType.json
+++ b/src/main/resources/swagger.api/schemas/entityType.json
@@ -13,9 +13,13 @@
         "description": "The unique name of entity type like User, Loan, Item, etc.",
         "type": "string"
       },
-      "labelAlias" : {
+      "labelAlias": {
         "description": "The identifier used for a localized label/name for this entity.",
         "type": "string"
+      },
+      "root": {
+        "description": "Indicates if this is a root entity (true) or derived entity (false)",
+        "type": "boolean"
       },
       "columns": {
         "type": "array",
@@ -35,6 +39,7 @@
     "required": [
       "id",
       "name",
+      "root",
       "columns"
     ]
   }

--- a/src/main/resources/swagger.api/schemas/entityTypeColumn.json
+++ b/src/main/resources/swagger.api/schemas/entityTypeColumn.json
@@ -26,6 +26,20 @@
        "type": "object",
         "$ref": "valueWithLabel.json"
       }
+    },
+    "idColumnName": {
+      "description": "Name of the corresponding ID column, if this column contains the value of an ID.",
+      "type": "string"
+    },
+    "source": {
+      "description": "Reference to the root entity type column, from where the values of this column is sourced from.",
+      "type": "object",
+      "$ref": "sourceColumn.json"
+    },
+    "valueGetter": {
+      "description": "Configuration defining how to fetch values of this column from the underlying datasource.",
+      "type": "object",
+      "$ref": "columnValueGetter.json"
     }
   },
   "required": [

--- a/src/main/resources/swagger.api/schemas/resultset.json
+++ b/src/main/resources/swagger.api/schemas/resultset.json
@@ -19,8 +19,7 @@
       }
     },
     "required": [
-      "content",
-      "totalRecords"
+      "content"
     ],
     "additionalProperties": false
   },
@@ -41,7 +40,20 @@
       }
     },
     "required": [
-      "content",
+      "content"
+    ],
+    "additionalProperties": false
+  },
+  "TotalRecords": {
+    "description": "Total records matching a query.",
+    "type": "object",
+    "properties": {
+      "totalRecords": {
+        "description": "The total number of records matching a query.",
+        "type": "integer"
+      }
+    },
+    "required": [
       "totalRecords"
     ],
     "additionalProperties": false

--- a/src/main/resources/swagger.api/schemas/sourceColumn.json
+++ b/src/main/resources/swagger.api/schemas/sourceColumn.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Source of an entity type column",
+  "description": "Source of an entity type column",
+  "type": "object",
+  "properties": {
+    "entityTypeId": {
+      "description": "A UUID identifying the source entity type",
+      "type": "string"
+    },
+    "columnName": {
+      "description": "Name of the source column",
+      "type": "string"
+    }
+  },
+  "required": [
+    "entityTypeId",
+    "columnName"
+  ]
+}


### PR DESCRIPTION
## Purpose

1. Define a new API to fetch records count for an FQL query
2. Define a new API to fetch the possible values in an entity type column
3. Add "idColumnName", "source" and "valueGetter" fields to column definition
4. Add "entityTypeId" query parameter to "/query" API

## Approach
_How does this change fulfill the purpose?_

#### TODOS and Open Questions
None

## Learning
N/A