### PR TITLE
US1112198: Add 'private' and 'subEntityTypeIds' fields to EntityType definition schema

### DIFF
--- a/src/main/resources/swagger.api/schemas/columnValues.json
+++ b/src/main/resources/swagger.api/schemas/columnValues.json
@@ -5,7 +5,7 @@
   "type": "object",
   "properties": {
     "content": {
-      "description": "Array of label & value pair",
+      "description": "Array of label and value pair",
       "type": "array",
       "items": {
         "type": "object",

--- a/src/main/resources/swagger.api/schemas/entityType.json
+++ b/src/main/resources/swagger.api/schemas/entityType.json
@@ -21,6 +21,18 @@
         "description": "Indicates if this is a root entity (true) or derived entity (false)",
         "type": "boolean"
       },
+      "private": {
+        "description": "This flag denotes whether the entity type is private or not. Private entity types cannot be accessed by users for querying.",
+        "type": "boolean"
+      },
+      "subEntityTypeIds": {
+        "description": "The IDs of the entity types that encompass a subset of the columns in this particular entity type.",
+        "type": "array",
+        "items": {
+          "type": "object",
+          "$ref": "common.json#/UUID"
+        }
+      },
       "columns": {
         "type": "array",
         "items": {
@@ -40,7 +52,8 @@
       "id",
       "name",
       "root",
-      "columns"
+      "columns",
+      "private"
     ]
   }
 }


### PR DESCRIPTION


## Purpose
Add 'private' and 'subEntityTypeIds' fields to EntityType definition schema

## Approach
Add 'private' and 'subEntityTypeIds' fields to EntityType definition schema

#### TODOS and Open Questions
None

## Learning
N/A
