### PR TITLE
US1151239: Use the FQM API instead of going to its DB schema

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,7 @@
               <generateApiTests>true</generateApiTests>
               <generateApiDocumentation>true</generateApiDocumentation>
               <generateModels>true</generateModels>
-              <modelsToGenerate>entityDataType,arrayType,dateType,entityTypeRelation,objectType,entityTypeColumn,enumType,booleanType,entityType,integerType,openUUIDType,stringType,numberType,rangedUUIDType,valueWithLabel,entityTypeDefaultSort,errors,error,parameters,parameter,resultsetPage,queryDetails,queryIdentifier,sourceColumn,columnValues,columnValueGetter,submitQuery</modelsToGenerate>
+              <modelsToGenerate>entityDataType,arrayType,dateType,entityTypeRelation,objectType,entityTypeColumn,enumType,booleanType,entityType,integerType,openUUIDType,stringType,numberType,rangedUUIDType,valueWithLabel,entityTypeDefaultSort,errors,error,parameters,parameter,resultsetPage,queryDetails,queryIdentifier,sourceColumn,columnValues,columnValueGetter,submitQuery,contentsRequest</modelsToGenerate>
               <generateModelTests>false</generateModelTests>
               <generateModelDocumentation>true</generateModelDocumentation>
               <generateSupportingFiles>true</generateSupportingFiles>

--- a/src/main/resources/swagger.api/queryTool.yaml
+++ b/src/main/resources/swagger.api/queryTool.yaml
@@ -133,7 +133,51 @@ paths:
           description: Query has been deleted
         '404':
           description: Query with id not found
-
+  /query/{queryId}/sortedIds:
+    get:
+      operationId: getSortedIds
+      description: Get ids of query results in sorted order
+      tags:
+        - fqlQuery
+      parameters:
+        - $ref: '#/components/parameters/queryId'
+        - $ref: '#/components/parameters/offset'
+        - $ref: '#/components/parameters/limit'
+      responses:
+        '200':
+          description: 'Details of the submitted query'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/queryResultIds'
+        '400':
+          $ref: '#/components/responses/badRequestResponse'
+        '500':
+          $ref: '#/components/responses/internalServerErrorResponse'
+  /query/contents:
+    post:
+      tags:
+        - fqlQuery
+      operationId: getContents
+      description: get contents for list of ids
+      requestBody:
+        description: Contents request
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/contentsRequest'
+      responses:
+        '200':
+          description: A page of list contents
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/contents'
+        '400':
+          $ref: '#/components/responses/badRequestResponse'
+        '500':
+          $ref: '#/components/responses/internalServerErrorResponse'
 components:
   parameters:
     entityTypeId:
@@ -269,6 +313,23 @@ components:
       $ref: schemas/columnValues.json
     submitQuery:
       $ref: schemas/query.json#/SubmitQuery
+    contentsRequest:
+      $ref: schemas/query.json#/ContentsRequest
+    queryResultIds:
+      type: array
+      items:
+        type: string
+        format: UUID
+    fields:
+      type: array
+      items:
+        type: string
+    contents:
+      type: array
+      items:
+        type: object
+        additionalProperties:
+          type: object
 
   responses:
     badRequestResponse:

--- a/src/main/resources/swagger.api/schemas/query.json
+++ b/src/main/resources/swagger.api/schemas/query.json
@@ -110,5 +110,36 @@
       "fqlQuery"
     ],
     "additionalProperties": false
+  },
+  "ContentsRequest": {
+    "description": "Request for a set of contents",
+    "type": "object",
+    "properties": {
+      "entityTypeId": {
+        "type": "object",
+        "$ref": "common.json#/UUID"
+      },
+      "fields": {
+        "description": "Fields to be included in results",
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "ids": {
+        "description": "Ids to retrieve results for",
+        "type": "array",
+        "items": {
+          "type": "string",
+          "format": "UUID"
+        }
+      }
+    },
+    "required": [
+      "entityTypeId",
+      "fields",
+      "ids"
+    ],
+    "additionalProperties": false
   }
 }


### PR DESCRIPTION
## Purpose
[US1151239](https://rally1.rallydev.com/#/?detail=/userstory/719697203519&fdp=true): mod-list-app: Use the FQM API instead of going to its DB schema

Implementation of above ticket requires new APIs to be defined in this repository.

2 new APIs were defined to make this possible. 

- GET /query/{queryId}/sortedIds - This API is used to get the ids for a query in sorted order. This is needed because mod-lists can't access the underlying views directly since they are in mod-fqm-manager.

- GET /query/contents - This API is used to get the full result set for a list of ids. This is needed because mod-lists only stores an element's id and sort sequence in the list contents table. The actual content for the ids needs to be retrieved from the views in mod-fqm-manager. But since mod-lists isn't allowed to access those directly, it needs to do so through an API call.
  - This API accepts an entity type id, a list of fields to retrieve, and a list of ids to retrieve content for. It's kind of messy as a GET request so we can also make it into a POST (with a requestBody instead of parameters).
  - We may also want to rename it since it's not directly tied to any specific query.

## Testing
TBD
