### PR TITLE
DE80812:Dropdown typeahead should use contains not starts with

### DIFF
--- a/src/main/resources/swagger.api/queryTool.yaml
+++ b/src/main/resources/swagger.api/queryTool.yaml
@@ -13,6 +13,7 @@ paths:
         - entity-types
       parameters:
         - $ref: '#/components/parameters/entityTypeId'
+        - $ref: '#/components/parameters/search'
       responses:
         '200':
           description: 'Definition of the requested entity type'


### PR DESCRIPTION
[DE80812](https://rally1.rallydev.com/#/?detail=/defect/719475123739&fdp=true): [Query builder] Dropdown typeahead should use contains not starts with