### PR TITLE
FQTM-4: Fix api-lint errors with the examples

### DIFF
--- a/src/main/resources/swagger.api/queryTool.yaml
+++ b/src/main/resources/swagger.api/queryTool.yaml
@@ -219,7 +219,7 @@ components:
       name: includeResults
       in: query
       required: false
-      description: Indicates if query results has to be included in the query details response
+      description: Indicates if query results should be included in the query details response
       schema:
         type: boolean
     fqlQuery:

--- a/src/main/resources/swagger.api/schemas/columnValues.json
+++ b/src/main/resources/swagger.api/schemas/columnValues.json
@@ -8,7 +8,6 @@
       "description": "Array of label and value pair",
       "type": "array",
       "items": {
-        "type": "object",
         "$ref": "valueWithLabel.json"
       }
     }

--- a/src/main/resources/swagger.api/schemas/entityType.json
+++ b/src/main/resources/swagger.api/schemas/entityType.json
@@ -29,21 +29,18 @@
         "description": "The IDs of the entity types that encompass a subset of the columns in this particular entity type.",
         "type": "array",
         "items": {
-          "type": "object",
           "$ref": "common.json#/UUID"
         }
       },
       "columns": {
         "type": "array",
         "items": {
-          "type": "object",
           "$ref": "entityTypeColumn.json"
         }
       },
       "defaultSort": {
         "type": "array",
         "items": {
-          "type": "object",
           "$ref": "entityTypeDefaultSort.json"
         }
       }

--- a/src/main/resources/swagger.api/schemas/entityTypeColumn.json
+++ b/src/main/resources/swagger.api/schemas/entityTypeColumn.json
@@ -24,7 +24,6 @@
       "type": "array",
       "description": "Array of values for this column",
       "items": {
-       "type": "object",
         "$ref": "valueWithLabel.json"
       }
     },
@@ -33,13 +32,11 @@
       "type": "string"
     },
     "source": {
-      "description": "Reference to the root entity type column, from where the values of this column is sourced from.",
-      "type": "object",
+      "description": "Reference to the root entity type column, from where the values of this column are sourced.",
       "$ref": "sourceColumn.json"
     },
     "valueGetter": {
       "description": "Configuration defining how to fetch values of this column from the underlying datasource.",
-      "type": "object",
       "$ref": "columnValueGetter.json"
     }
   },

--- a/src/main/resources/swagger.api/schemas/error/error.json
+++ b/src/main/resources/swagger.api/schemas/error/error.json
@@ -15,7 +15,6 @@
       "description": "Error message code"
     },
     "parameters": {
-      "type": "object",
       "description": "Error message parameters",
       "$ref": "parameters.json"
     }

--- a/src/main/resources/swagger.api/schemas/error/errors.json
+++ b/src/main/resources/swagger.api/schemas/error/errors.json
@@ -7,7 +7,6 @@
       "id": "errors",
       "type": "array",
       "items": {
-        "type": "object",
         "$ref": "error.json"
       }
     },

--- a/src/main/resources/swagger.api/schemas/error/parameters.json
+++ b/src/main/resources/swagger.api/schemas/error/parameters.json
@@ -2,8 +2,6 @@
   "description": "List of key/value parameters of an error",
   "type": "array",
   "items": {
-    "type": "object",
     "$ref": "parameter.json"
-  },
-  "additionalProperties": false
+  }
 }

--- a/src/main/resources/swagger.api/schemas/query.json
+++ b/src/main/resources/swagger.api/schemas/query.json
@@ -10,7 +10,6 @@
         "description": "The rows of the page.",
         "type": "array",
         "items": {
-          "type": "object",
           "$ref": "#/ResultsetContent"
         }
       },
@@ -80,7 +79,6 @@
     "type": "object",
     "properties": {
       "queryId": {
-        "type": "object",
         "$ref": "common.json#/UUID"
       }
     },
@@ -94,7 +92,6 @@
         "type": "string"
       },
       "entityTypeId": {
-        "type": "object",
         "$ref": "common.json#/UUID"
       },
       "fields": {
@@ -116,7 +113,6 @@
     "type": "object",
     "properties": {
       "entityTypeId": {
-        "type": "object",
         "$ref": "common.json#/UUID"
       },
       "fields": {

--- a/src/main/resources/swagger.api/schemas/resultset.json
+++ b/src/main/resources/swagger.api/schemas/resultset.json
@@ -10,7 +10,6 @@
         "description": "The rows of the page.",
         "type": "array",
         "items": {
-          "type": "object",
           "$ref": "#/ResultsetContent"
         }
       },

--- a/src/main/resources/swagger.api/schemas/sourceColumn.json
+++ b/src/main/resources/swagger.api/schemas/sourceColumn.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Source of an entity type column",
-  "description": "Source of an entity type column",
+  "description": "Source of an entity type column, from where the values for the column can be derived",
   "type": "object",
   "properties": {
     "entityTypeId": {


### PR DESCRIPTION
## Purpose
[Fix api-lint errors with the examples](https://issues.folio.org/browse/FQTM-4)

## Testing
- [x] No lint errors
- Note: there are still 2 warnings that occur during compilation due to the use of the `allOf` parameter. However, these have always been present and don't seem to be causing any problems so it may be ok to leave it for now.
