### PR TITLE
MODFQMMGR-79 Add filterValueGetter to entityTypeColumn

### DIFF
--- a/src/main/resources/swagger.api/schemas/entityTypeColumn.json
+++ b/src/main/resources/swagger.api/schemas/entityTypeColumn.json
@@ -38,6 +38,10 @@
     "valueGetter": {
       "description": "Configuration defining how to fetch values of this column from the underlying datasource.",
       "$ref": "columnValueGetter.json"
+    },
+    "filterValueGetter": {
+      "description": "Configuration defining how to filter values of this column from the underlying datasource when indexed values aren't very user-friendly.",
+      "type": "string"
     }
   },
   "required": [


### PR DESCRIPTION
This new property will allow us to specify a column accessor that is different from what the user actually sees. The current use case for this is columns with an index on left(lower(f_unaccent(column)), 600). We want to use that form in the WHERE clause of queries, but want the user to see it without the extra processing.
