### PR TITLE
Add optional groupByFields to entity type definition

### DIFF
--- a/src/main/resources/swagger.api/schemas/entityType.json
+++ b/src/main/resources/swagger.api/schemas/entityType.json
@@ -51,6 +51,13 @@
       "idView": {
         "description": "View from which the content IDs for this entity type are extracted",
         "type": "string"
+      },
+      "groupByFields": {
+        "description": "Ordered list of fields used in the GROUP BY clause for this entity type",
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
       }
     },
     "required": [


### PR DESCRIPTION
## Purpose
Add optional groupByFields to entity type definition. This field can be used for queries that need a group by clause, such as those for array fields.
