### PR TITLE
MODFQMMGR-116 Add valueFunction to EntityTypeColumn

### DIFF
--- a/src/main/resources/swagger.api/schemas/entityTypeColumn.json
+++ b/src/main/resources/swagger.api/schemas/entityTypeColumn.json
@@ -42,6 +42,10 @@
     "filterValueGetter": {
       "description": "Configuration defining how to filter values of this column from the underlying datasource when indexed values aren't very user-friendly.",
       "type": "string"
+    },
+    "valueFunction": {
+      "description": "Configuration defining how to transform a static value for comparison with values produced by the filterValueGetter. This is useful when the filterValueGetter does extra processing that is not visible to the user. The static value can be referenced with ':value'",
+      "type": "string"
     }
   },
   "required": [


### PR DESCRIPTION
This function allows us to define a custom function for each column to do any additional processing needed on a query condition's value. For example, if a column's filterValueGetter is defined as "left(lower(f_unaccent(jsob ->> 'something')), 10)", then we can set the valueFunction to "left(lower(f_unaccent(:value)), 10)" to make it so both sides of a "column <operator> value" comparison have the same processing applied