### PR TITLE
[MODFQMMGR-150] Add nested object types

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,7 @@
               <generateApiTests>true</generateApiTests>
               <generateApiDocumentation>true</generateApiDocumentation>
               <generateModels>true</generateModels>
-              <modelsToGenerate>entityDataType,arrayType,dateType,entityTypeRelation,objectType,entityTypeColumn,enumType,booleanType,entityType,integerType,openUUIDType,stringType,numberType,rangedUUIDType,valueWithLabel,entityTypeDefaultSort,errors,error,parameters,parameter,resultsetPage,queryDetails,queryIdentifier,sourceColumn,columnValues,columnValueGetter,submitQuery,contentsRequest</modelsToGenerate>
+              <modelsToGenerate>entityDataType,arrayType,dateType,entityTypeRelation,objectType,nestedObjectProperty,entityTypeColumn,enumType,booleanType,entityType,integerType,openUUIDType,stringType,numberType,rangedUUIDType,valueWithLabel,entityTypeDefaultSort,errors,error,parameters,parameter,resultsetPage,queryDetails,queryIdentifier,sourceColumn,columnValues,columnValueGetter,submitQuery,contentsRequest</modelsToGenerate>
               <generateModelTests>false</generateModelTests>
               <generateModelDocumentation>true</generateModelDocumentation>
               <generateSupportingFiles>true</generateSupportingFiles>

--- a/src/main/resources/swagger.api/queryTool.yaml
+++ b/src/main/resources/swagger.api/queryTool.yaml
@@ -311,6 +311,10 @@ components:
       $ref: schemas/entityDataType.json#/EnumType
     objectType:
       $ref: schemas/entityDataType.json#/ObjectType
+    objectTypeContainer:
+      $ref: schemas/entityDataType.json#/ObjectTypeContainer
+    nestedObjectProperty:
+      $ref: schemas/entityDataType.json#/NestedObjectProperty
     arrayType:
       $ref: schemas/entityDataType.json#/ArrayType
     entityTypeDefaultSort:

--- a/src/main/resources/swagger.api/schemas/entityDataType.json
+++ b/src/main/resources/swagger.api/schemas/entityDataType.json
@@ -9,9 +9,7 @@
         "type": "string"
       }
     },
-    "required": [
-      "dataType"
-    ],
+    "required": ["dataType"],
     "discriminator": {
       "propertyName": "dataType"
     }
@@ -79,18 +77,6 @@
       }
     ]
   },
-  "ObjectTypeContainer": {
-    "type": "object",
-    "properties": {
-      "objectDefinition": {
-        "description": "The entity type describing the complex column when the data type is OBJECT.",
-        "$ref": "entityType.json#/EntityType"
-      }
-    },
-    "required": [
-      "objectDefinition"
-    ]
-  },
   "ObjectType": {
     "description": "Entity field type defined in https://issues.folio.org/browse/UIPQB-10",
     "allOf": [
@@ -102,6 +88,49 @@
       }
     ]
   },
+  "ObjectTypeContainer": {
+    "type": "object",
+    "properties": {
+      "properties": {
+        "description": "A list of this object's properties",
+        "type": "array",
+        "items": {
+          "$ref": "entityDataType.json#/NestedObjectProperty"
+        }
+      }
+    },
+    "required": ["properties"]
+  },
+  "NestedObjectProperty": {
+    "type": "object",
+    "description": "A property within an object",
+    "properties": {
+      "name": {
+        "description": "The name of the property",
+        "type": "string"
+      },
+      "key": {
+        "description": "The key of the property inside the object",
+        "type": "string"
+      },
+      "labelAlias": {
+        "description": "The human-readable label for this property; should be unqualified (e.g. 'Name' instead of 'User's Name')",
+        "type": "string"
+      },
+      "dataType": {
+        "description": "The data type of the property",
+        "$ref": "entityDataType.json#/EntityDataType"
+      },
+      "values": {
+        "type": "array",
+        "description": "Array of values for this column",
+        "items": {
+          "$ref": "valueWithLabel.json"
+        }
+      }
+    },
+    "required": ["name", "key", "dataType"]
+  },
   "ArrayTypeContainer": {
     "type": "object",
     "properties": {
@@ -110,9 +139,7 @@
         "$ref": "entityDataType.json#/EntityDataType"
       }
     },
-    "required": [
-      "itemDataType"
-    ]
+    "required": ["itemDataType"]
   },
   "ArrayType": {
     "description": "Entity field type defined in https://issues.folio.org/browse/UIPQB-6",


### PR DESCRIPTION
## Purpose
Some fields, such as purchase order lines' fund distributions, are arrays of objects. To enable better display and querying of these fields, we need to store metadata about these nested properties (data types, labels, etc).