### PR TITLE
[FQTM-6] Add fully qualified nested property label

### DIFF
--- a/src/main/resources/swagger.api/schemas/entityDataType.json
+++ b/src/main/resources/swagger.api/schemas/entityDataType.json
@@ -105,6 +105,16 @@
     "allOf": [
       {
         "$ref": "./field.json"
+      },
+      {
+        "type": "object",
+        "properties": {
+          "labelAliasFullyQualified": {
+            "description": "A localized and fully qualified alias for the label of the nested property, e.g. 'Parent - Nested Property'",
+            "type": "string"
+          }
+        },
+        "required": []
       }
     ]
   },

--- a/src/main/resources/swagger.api/schemas/field.json
+++ b/src/main/resources/swagger.api/schemas/field.json
@@ -13,7 +13,7 @@
       "$ref": "entityDataType.json#/EntityDataType"
     },
     "labelAlias": {
-      "description": "The identifier used for a localized label/name for this column.",
+      "description": "A pre-localized identifier used to label/name this column.",
       "type": "string"
     },
     "source": {


### PR DESCRIPTION
# [Jira FQTM-6](https://folio-org.atlassian.net/browse/FQTM-6)

## Purpose

Left this out of #42 ; we want this fully qualified label for use in the query builder and when selecting columns in the result viewer.

For example, fund distributions:
- Parent `fund_distributions` column: `labelAlias=Fund distribution`
- Child `amount` property: `labelAlias=Amount` (for showing within results)
- Child `amount` property: `labelAliasFullyQualified=Fund distribution — amount` or `Fund distribution amount`, etc.