### PR TITLE
[FQTM-7] Use openapi-generator v7.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
   <properties>
     <java.version>17</java.version>
-    <openapi-generator.version>6.6.0</openapi-generator.version>
+    <openapi-generator.version>7.3.0</openapi-generator.version>
     <maven-compat.version>3.8.7</maven-compat.version>
     <yaml.file>${project.basedir}/src/main/resources/swagger.api/queryTool.yaml</yaml.file>
     <lombok.version>1.18.24</lombok.version>


### PR DESCRIPTION
# [Jira FQTM-7](https://folio-org.atlassian.net/browse/FQTM-7)

## Purpose

Update `openapi-generator` to v7.3.0. We need at least v7.0.0 due to the (for us) breaking change in v6.5.0, which erroneously added a `@deprecated` annotation to the default no-args constructor, breaking our javadoc compilation and thus our builds. See https://github.com/OpenAPITools/openapi-generator/issues/15478 for more details.