### PR TITLE
[LIBFQMQUER-12] Generalize idColumnName to Field intead of EntityTypeColumn

### DIFF
--- a/src/main/resources/swagger.api/schemas/entityTypeColumn.json
+++ b/src/main/resources/swagger.api/schemas/entityTypeColumn.json
@@ -13,10 +13,6 @@
           "description": "Indicates if the column should be shown by default when the entity is viewed.",
           "type": "boolean"
         },
-        "idColumnName": {
-          "description": "Name of the corresponding ID column, if this column contains the value of an ID.",
-          "type": "string"
-        },
         "isCustomField": {
           "description": "Indicates if the column belongs to the custom field.",
           "type": "boolean"

--- a/src/main/resources/swagger.api/schemas/field.json
+++ b/src/main/resources/swagger.api/schemas/field.json
@@ -32,6 +32,10 @@
       "description": "Configuration defining how to filter values of this column from the underlying datasource when indexed values aren't very user-friendly.",
       "type": "string"
     },
+    "idColumnName": {
+      "description": "Name of the corresponding ID column, if this column contains the value of an ID.",
+      "type": "string"
+    },
     "valueFunction": {
       "description": "Configuration defining how to transform a static value for comparison with values produced by the filterValueGetter. This is useful when the filterValueGetter does extra processing that is not visible to the user. The static value can be referenced with ':value'",
       "type": "string"


### PR DESCRIPTION
# [Jira LIBFQMQUER-12](https://folio-org.atlassian.net/browse/LIBFQMQUER-12)

## Purpose
`idColumnName` should apply to `Field`, since theoretically there's no reason we couldn't have nested properties with the same kind of id column mapping logic.