### PR TITLE
MODFQMMGR-268 Add required permissions to EntityType

### DIFF
--- a/src/main/resources/swagger.api/schemas/entityType.json
+++ b/src/main/resources/swagger.api/schemas/entityType.json
@@ -77,6 +77,14 @@
         "items": {
           "$ref": "entityTypeSource.json"
         }
+      },
+      "requiredPermissions": {
+        "description": "List of permissions required to query this entity type",
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "default": []
       }
     },
     "required": [


### PR DESCRIPTION
This will allow us to specify what permissions are required for specific entity types, in addition to the very broad FQM API permissions