### PR TITLE
MODFQMMGR-313 Add a default for entity type columns

### DIFF
--- a/src/main/resources/swagger.api/schemas/entityType.json
+++ b/src/main/resources/swagger.api/schemas/entityType.json
@@ -40,7 +40,8 @@
         "type": "array",
         "items": {
           "$ref": "entityTypeColumn.json"
-        }
+        },
+        "default": []
       },
       "defaultSort": {
         "type": "array",


### PR DESCRIPTION
This will allow us to deal with entity types without columns fairly easily in mod-fqm-manager, rather than having to constantly check to see if it's null