### PR TITLE
MODFQMMGR-378 Update approach to enabling ECS for an entity type

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -197,7 +197,7 @@
               <generateApiTests>true</generateApiTests>
               <generateApiDocumentation>true</generateApiDocumentation>
               <generateModels>true</generateModels>
-              <modelsToGenerate>entityDataType,arrayType,dateType,entityTypeRelation,objectType,nestedObjectProperty,entityTypeColumn,enumType,booleanType,entityType,integerType,openUUIDType,stringType,numberType,rangedUUIDType,valueWithLabel,entityTypeDefaultSort,errors,error,parameters,parameter,resultsetPage,queryDetails,queryIdentifier,sourceColumn,valueSourceApi,columnValues,columnValueGetter,submitQuery,contentsRequest,field,entityTypeSource,entityTypeSourceJoin,stringUUIDType,entityTypeCrossTenantQueryConfig</modelsToGenerate>
+              <modelsToGenerate>entityDataType,arrayType,dateType,entityTypeRelation,objectType,nestedObjectProperty,entityTypeColumn,enumType,booleanType,entityType,integerType,openUUIDType,stringType,numberType,rangedUUIDType,valueWithLabel,entityTypeDefaultSort,errors,error,parameters,parameter,resultsetPage,queryDetails,queryIdentifier,sourceColumn,valueSourceApi,columnValues,columnValueGetter,submitQuery,contentsRequest,field,entityTypeSource,entityTypeSourceJoin,stringUUIDType</modelsToGenerate>
               <generateModelTests>false</generateModelTests>
               <generateModelDocumentation>true</generateModelDocumentation>
               <generateSupportingFiles>true</generateSupportingFiles>

--- a/src/main/resources/swagger.api/schemas/entityType.json
+++ b/src/main/resources/swagger.api/schemas/entityType.json
@@ -43,9 +43,10 @@
         },
         "default": []
       },
-      "crossTenantQueryConfig": {
-        "description": "Cross-tenant query config for this entity type. Cross-tenant queries are not supported for entity types without this property.",
-        "$ref": "entityTypeCrossTenantQueryConfig.json"
+      "crossTenantQueriesEnabled": {
+        "description": "Indicates if this entity type supports cross-tenant queries",
+        "type": "boolean",
+        "default": false
       },
       "defaultSort": {
         "type": "array",

--- a/src/main/resources/swagger.api/schemas/sourceColumn.json
+++ b/src/main/resources/swagger.api/schemas/sourceColumn.json
@@ -5,7 +5,20 @@
   "type": "object",
   "properties": {
     "entityTypeId": {
-      "description": "A UUID identifying the source entity type",
+      "description": "A UUID identifying the source entity type.",
+      "type": "string"
+    },
+    "type": {
+      "description": "Name of the source type. Possible values: entity-type, fqm. Default: entity-type",
+      "type": "string",
+      "default": "entity-type",
+      "enum": [
+        "entity-type",
+        "fqm"
+      ]
+    },
+    "name": {
+      "description": "Name of the source within the source type (e.g., 'currency')",
       "type": "string"
     },
     "columnName": {
@@ -14,7 +27,6 @@
     }
   },
   "required": [
-    "entityTypeId",
-    "columnName"
+    "entityTypeId", "columnName"
   ]
 }


### PR DESCRIPTION
This commit adds a new boolean crossTenantQueriesEnabled property to entity types, to control when an entity type supports cross-query queries. It also changes the shape of the entity type column "source" property's object model, adding a new "type" property. This new property will allow us to use the "source" to define value sources that come from things besides entity types. There's also a new "name" property, which is for setting the name of the value provider within the source type

## Purpose
_Describe the purpose of the pull request. Include background information if necessary._

## Approach
_How does this change fulfill the purpose?_

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
