### PR TITLE
[MODLISTS-129] Move migration request/response types from mod-fqm-manager

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -198,12 +198,13 @@
               <generateApiDocumentation>true</generateApiDocumentation>
               <generateModels>true</generateModels>
               <modelsToGenerate>
-                errors,error,parameters,parameter,resultsetPage,
-                field,entityTypeColumn,entityTypeRelation,entityTypeDefaultSort,sourceColumn,entityTypeSource,entityTypeSourceJoin,
-                entityDataType,arrayType,dateType,objectType,enumType,booleanType,entityType,integerType,openUUIDType,stringType,numberType,rangedUUIDType,stringUUIDType
-                nestedObjectProperty,valueWithLabel,valueSourceApi,columnValues,columnValueGetter,
-                queryDetails,queryIdentifier,
-                submitQuery,contentsRequest,fqmMigrateRequest,fqmMigrateResponse,fqmMigrateWarning
+                <!-- the commas at the start and end of each line are load-bearing, as otherwise openapi-generator will include the newline/indentation as part of the model name -->
+                ,errors,error,parameters,parameter,resultsetPage,
+                ,entityType,field,entityTypeColumn,entityTypeRelation,entityTypeDefaultSort,sourceColumn,entityTypeSource,entityTypeSourceJoin,
+                ,entityDataType,arrayType,dateType,objectType,enumType,booleanType,integerType,openUUIDType,stringType,numberType,rangedUUIDType,stringUUIDType,
+                ,nestedObjectProperty,valueWithLabel,valueSourceApi,columnValues,columnValueGetter,
+                ,queryDetails,queryIdentifier,
+                ,submitQuery,contentsRequest,fqmMigrateRequest,fqmMigrateResponse,fqmMigrateWarning
               </modelsToGenerate>
               <generateModelTests>false</generateModelTests>
               <generateModelDocumentation>true</generateModelDocumentation>

--- a/pom.xml
+++ b/pom.xml
@@ -197,7 +197,14 @@
               <generateApiTests>true</generateApiTests>
               <generateApiDocumentation>true</generateApiDocumentation>
               <generateModels>true</generateModels>
-              <modelsToGenerate>entityDataType,arrayType,dateType,entityTypeRelation,objectType,nestedObjectProperty,entityTypeColumn,enumType,booleanType,entityType,integerType,openUUIDType,stringType,numberType,rangedUUIDType,valueWithLabel,entityTypeDefaultSort,errors,error,parameters,parameter,resultsetPage,queryDetails,queryIdentifier,sourceColumn,valueSourceApi,columnValues,columnValueGetter,submitQuery,contentsRequest,field,entityTypeSource,entityTypeSourceJoin,stringUUIDType</modelsToGenerate>
+              <modelsToGenerate>
+                errors,error,parameters,parameter,resultsetPage,
+                field,entityTypeColumn,entityTypeRelation,entityTypeDefaultSort,sourceColumn,entityTypeSource,entityTypeSourceJoin,
+                entityDataType,arrayType,dateType,objectType,enumType,booleanType,entityType,integerType,openUUIDType,stringType,numberType,rangedUUIDType,stringUUIDType
+                nestedObjectProperty,valueWithLabel,valueSourceApi,columnValues,columnValueGetter,
+                queryDetails,queryIdentifier,
+                submitQuery,contentsRequest,fqmMigrateRequest,fqmMigrateResponse,fqmMigrateWarning
+              </modelsToGenerate>
               <generateModelTests>false</generateModelTests>
               <generateModelDocumentation>true</generateModelDocumentation>
               <generateSupportingFiles>true</generateSupportingFiles>

--- a/src/main/resources/swagger.api/queryTool.yaml
+++ b/src/main/resources/swagger.api/queryTool.yaml
@@ -352,6 +352,12 @@ components:
       $ref: schemas/query.json#/SubmitQuery
     contentsRequest:
       $ref: schemas/query.json#/ContentsRequest
+
+    fqmMigrateRequest:
+      $ref: schemas/fqmMigrateRequest.json
+    fqmMigrateResponse:
+      $ref: schemas/fqmMigrateResponse.json
+
     queryResultIds:
       type: array
       items:
@@ -375,7 +381,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/errors"
+            $ref: '#/components/schemas/errors'
     internalServerErrorResponse:
       description: When unhandled exception occurred during code execution, e.g. NullPointerException
       content:
@@ -386,5 +392,4 @@ components:
                 code: unexpected.error
             total_records: 1
           schema:
-            $ref: "#/components/schemas/errors"
-
+            $ref: '#/components/schemas/errors'

--- a/src/main/resources/swagger.api/schemas/fqmMigrateRequest.json
+++ b/src/main/resources/swagger.api/schemas/fqmMigrateRequest.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Entity Upgrade Request",
+  "description": "Schema for a request to upgrade an entity payload, including an entity type ID, FQL query, and list of fields.",
+  "type": "object",
+  "properties": {
+    "entityTypeId": {
+      "description": "ID of the entity type to be upgraded",
+      "type": "string",
+      "format": "UUID"
+    },
+    "fqlQuery": {
+      "description": "FQL query string to be upgraded",
+      "type": "string"
+    },
+    "fields": {
+      "description": "List of fields to be upgraded",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "required": ["entityTypeId"]
+}

--- a/src/main/resources/swagger.api/schemas/fqmMigrateResponse.json
+++ b/src/main/resources/swagger.api/schemas/fqmMigrateResponse.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Entity Upgrade Response",
+  "description": "Schema for a migrated query, with associated entity type, fields, and potential warnings",
+  "type": "object",
+  "properties": {
+    "entityTypeId": {
+      "description": "ID of the post-upgrade entity type",
+      "type": "string",
+      "format": "uuid"
+    },
+    "fqlQuery": {
+      "description": "Post-upgrade FQL query string",
+      "type": "string"
+    },
+    "fields": {
+      "description": "Post-upgrade list of fields",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "warnings": {
+      "description": "List of warnings issued during the upgrade",
+      "type": "array",
+      "items": {
+        "$ref": "./fqmMigrateWarning.json"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "required": ["entityTypeId"]
+}

--- a/src/main/resources/swagger.api/schemas/fqmMigrateWarning.json
+++ b/src/main/resources/swagger.api/schemas/fqmMigrateWarning.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Entity Upgrade Response",
+  "description": "Warnings resulting from a query upgrade",
+  "type": "object",
+  "properties": {
+    "description": {
+      "description": "Description of the warning",
+      "type": "string"
+    },
+    "type": {
+      "description": "Type of warning",
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "required": ["description", "type"]
+}

--- a/src/main/resources/swagger.api/schemas/fqmMigrateWarning.json
+++ b/src/main/resources/swagger.api/schemas/fqmMigrateWarning.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "Entity Upgrade Response",
+  "title": "Entity Upgrade Warning",
   "description": "Warnings resulting from a query upgrade",
   "type": "object",
   "properties": {


### PR DESCRIPTION
This moves the schemas for migration requests/responses out of `mod-fqm-manager` to facilitate easy sharing between `mod-fqm-manager` and `mod-lists`