### PR TITLE
FQTM-10 Bump to spring-boot starter 3.3.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.2.2</version>
+    <version>3.3.5</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
   <groupId>org.folio</groupId>


### PR DESCRIPTION
This commit upgrades us from spring-boot-starter-parent v3.2.2 to v3.3.5, in order to move away from a few vulnerable dependencies