### PR TITLE
[FQTM-11] New entity type join model

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -218,7 +218,11 @@
                 <interfaceOnly>true</interfaceOnly>
                 <useSpringBoot3>true</useSpringBoot3>
                 <useTags>true</useTags>
-                <additionalModelTypeAnnotations>@lombok.experimental.SuperBuilder(toBuilder = true)</additionalModelTypeAnnotations>
+                <additionalModelTypeAnnotations>
+                  <!-- lombok's builder will generate a copy constructor that can shadow implicit no-args, so we make an explicit one -->
+                  @lombok.NoArgsConstructor
+                  @lombok.experimental.SuperBuilder(toBuilder = true)
+                </additionalModelTypeAnnotations>
               </configOptions>
               <openapiNormalizer>REF_AS_PARENT_IN_ALLOF=true</openapiNormalizer>
             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -202,7 +202,7 @@
                 ,errors,error,parameters,parameter,resultsetPage,
                 ,entityType,field,entityTypeColumn,entityTypeRelation,entityTypeDefaultSort,sourceColumn,
                 ,entityTypeSource,entityTypeSourceBase,entityTypeSourceDatabase,entityTypeSourceDatabaseJoin,entityTypeSourceEntityType,
-                ,join,joinCustom,joinEqualitySimple,joinEqualityCastUUID,
+                ,join,joinDirection,joinCustom,joinEqualitySimple,joinEqualityCastUUID,
                 ,entityDataType,arrayType,jsonbArrayType,dateType,objectType,enumType,booleanType,integerType,openUUIDType,stringType,numberType,rangedUUIDType,stringUUIDType,
                 ,nestedObjectProperty,valueWithLabel,valueSourceApi,columnValues,columnValueGetter
                 ,queryDetails,queryIdentifier,

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
   <properties>
     <java.version>17</java.version>
-    <openapi-generator.version>7.3.0</openapi-generator.version>
+    <openapi-generator.version>7.11.0</openapi-generator.version>
     <maven-compat.version>3.8.7</maven-compat.version>
     <yaml.file>${project.basedir}/src/main/resources/swagger.api/queryTool.yaml</yaml.file>
     <lombok.version>1.18.24</lombok.version>
@@ -200,7 +200,9 @@
               <modelsToGenerate>
                 <!-- the commas at the start and end of each line are load-bearing, as otherwise openapi-generator will include the newline/indentation as part of the model name -->
                 ,errors,error,parameters,parameter,resultsetPage,
-                ,entityType,field,entityTypeColumn,entityTypeRelation,entityTypeDefaultSort,sourceColumn,entityTypeSource,entityTypeSourceJoin,
+                ,entityType,field,entityTypeColumn,entityTypeRelation,entityTypeDefaultSort,sourceColumn,
+                ,entityTypeSource,entityTypeSourceBase,entityTypeSourceDatabase,entityTypeSourceDatabaseJoin,entityTypeSourceEntityType,
+                ,join,joinCustom,joinEqualitySimple,joinEqualityCastUUID,
                 ,entityDataType,arrayType,jsonbArrayType,dateType,objectType,enumType,booleanType,integerType,openUUIDType,stringType,numberType,rangedUUIDType,stringUUIDType,
                 ,nestedObjectProperty,valueWithLabel,valueSourceApi,columnValues,columnValueGetter
                 ,queryDetails,queryIdentifier,

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <openapi-generator.version>7.11.0</openapi-generator.version>
     <maven-compat.version>3.8.7</maven-compat.version>
     <yaml.file>${project.basedir}/src/main/resources/swagger.api/queryTool.yaml</yaml.file>
-    <lombok.version>1.18.24</lombok.version>
+    <lombok.version>1.18.36</lombok.version>
     <jackson-databind-nullable.version>0.2.4</jackson-databind-nullable.version>
     <snakeyaml.version>2.0</snakeyaml.version>
     <!-- -->

--- a/pom.xml
+++ b/pom.xml
@@ -58,13 +58,13 @@
           <artifactId>spring-boot-starter-logging</artifactId>
         </exclusion>
       </exclusions>
-      <!-- Making this dependency optional to avoid lib-frm-query-processor having transitive dependency on spring -->
+      <!-- Making this dependency optional to avoid lib-fqm-query-processor having transitive dependency on spring -->
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <optional>true</optional>
+      <scope>provided</scope>
     </dependency>
     <!-- OAS generation -->
     <dependency>
@@ -218,6 +218,7 @@
                 <interfaceOnly>true</interfaceOnly>
                 <useSpringBoot3>true</useSpringBoot3>
                 <useTags>true</useTags>
+                <additionalModelTypeAnnotations>@lombok.experimental.SuperBuilder(toBuilder = true)</additionalModelTypeAnnotations>
               </configOptions>
               <openapiNormalizer>REF_AS_PARENT_IN_ALLOF=true</openapiNormalizer>
             </configuration>

--- a/src/main/resources/swagger.api/queryTool.yaml
+++ b/src/main/resources/swagger.api/queryTool.yaml
@@ -326,6 +326,14 @@ components:
   schemas:
     UUID:
       $ref: schemas/common.json#/UUID
+
+    entityTypeSource:
+      $ref: schemas/entityTypeSource.json
+    entityTypeSourceDatabase:
+      $ref: schemas/entityTypeSourceDatabase.json
+    entityTypeSourceEntityType:
+      $ref: schemas/entityTypeSourceEntityType.json
+
     entityType:
       $ref: schemas/entityType.json#/EntityType
     entityDataType:
@@ -385,6 +393,15 @@ components:
       $ref: schemas/fqmMigrateRequest.json
     fqmMigrateResponse:
       $ref: schemas/fqmMigrateResponse.json
+
+    join:
+      $ref: schemas/field-joins/join.json
+    joinCustom:
+      $ref: schemas/field-joins/joinCustom.json
+    joinEqualitySimple:
+      $ref: schemas/field-joins/joinEqualitySimple.json
+    joinEqualityCastUUID:
+      $ref: schemas/field-joins/joinEqualityCastUUID.json
 
     queryResultIds:
       type: array

--- a/src/main/resources/swagger.api/schemas/entityType.json
+++ b/src/main/resources/swagger.api/schemas/entityType.json
@@ -25,13 +25,6 @@
         "description": "This flag denotes whether the entity type is private or not. Private entity types cannot be accessed by users for querying.",
         "type": "boolean"
       },
-      "subEntityTypeIds": {
-        "description": "The IDs of the entity types that encompass a subset of the columns in this particular entity type.",
-        "type": "array",
-        "items": {
-          "$ref": "common.json#/UUID"
-        }
-      },
       "customFieldEntityTypeId": {
         "description": "The IDs of the custom field entity type ",
         "type": "string"

--- a/src/main/resources/swagger.api/schemas/entityType.json
+++ b/src/main/resources/swagger.api/schemas/entityType.json
@@ -81,7 +81,7 @@
       "sources": {
         "type": "array",
         "items": {
-          "$ref": "entityTypeSource.json"
+          "$ref": "./entityTypeSource.json"
         },
         "default": []
       },
@@ -102,12 +102,6 @@
         "default": []
       }
     },
-    "required": [
-      "id",
-      "name",
-      "root",
-      "private"
-    ]
+    "required": ["id", "name", "root", "private"]
   }
 }
-

--- a/src/main/resources/swagger.api/schemas/entityTypeColumn.json
+++ b/src/main/resources/swagger.api/schemas/entityTypeColumn.json
@@ -33,10 +33,21 @@
         "essential": {
           "description": "Indicates if a column is crucial to the definition of an entity type",
           "type": "boolean"
+        },
+        "joinsTo": {
+          "description": "A set of columns which this column may be joined to",
+          "type": "array",
+          "items": {
+            "$ref": "./field-joins/join.json"
+          }
+        },
+        "originalEntityTypeId": {
+          "description": "[Internal only, not for definitions] The simplest entity type that this column is derived from",
+          "type": "string",
+          "format": "uuid"
         }
       },
       "required": []
     }
   ]
 }
-

--- a/src/main/resources/swagger.api/schemas/entityTypeSource.json
+++ b/src/main/resources/swagger.api/schemas/entityTypeSource.json
@@ -2,43 +2,31 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Entity Type Source",
   "description": "Definition for an entity type source, which provide a set of fields and can be joined with other sources",
-  "type": "object",
-  "properties": {
-    "type": {
-      "description": "Type of source. Valid values are db, entity-type.",
-      "type": "string"
-    },
-    "target": {
-      "description": "Target from which values are extracted",
-      "type": "string"
-    },
-    "alias": {
-      "description": "Alias of this source to be used in query",
-      "type": "string"
-    },
-    "id": {
-      "description": "Id of the entity type for this source (entity-type type only)",
-      "type": "string"
-    },
-    "join": {
-      "description": "Object describing how this entity type source can be joined to another source",
-      "$ref": "entityTypeSourceJoin.json"
-    },
-    "flattened": {
-      "description": "Whether this source has already been flattened",
-      "type": "boolean"
-    },
-    "useIdColumns": {
-      "description": "Whether to use the idColumns of this source as idColumns for the enclosing entity type",
-      "type": "boolean"
-    },
-    "essentialOnly": {
-      "description": "Indicates that only critical columns for core functionality should be inherited, excluding non-essential columns",
-      "type": "boolean"
+  "allOf": [
+    {
+      "type": "object",
+      "discriminator": {
+        "propertyName": "type",
+        "mapping": {
+          "db": "#/components/schemas/entityTypeSourceDatabase",
+          "entity-type": "#/components/schemas/entityTypeSourceEntityType"
+        }
+      },
+      "properties": {
+        "type": {
+          "description": "Type of source. Valid values are db, entity-type",
+          "type": "string"
+        },
+        "alias": {
+          "description": "Alias of this source to be used in query/later joins",
+          "type": "string"
+        },
+        "joinedViaEntityType": {
+          "description": "[Internal use only, should not be included in definitions] The owning entity's alias, if this source's joining is handled by a parent entity in a cross-entity join",
+          "type": "string"
+        }
+      },
+      "required": ["type", "alias"]
     }
-  },
-  "required": [
-    "type",
-    "alias"
   ]
 }

--- a/src/main/resources/swagger.api/schemas/entityTypeSourceDatabase.json
+++ b/src/main/resources/swagger.api/schemas/entityTypeSourceDatabase.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Entity Type Database Source",
+  "description": "Definition for an entity type source based on a database",
+  "allOf": [
+    {
+      "$ref": "./entityTypeSource.json"
+    },
+    {
+      "type": "object",
+      "properties": {
+        "target": {
+          "description": "Target view/table from which values are extracted",
+          "type": "string"
+        },
+        "join": {
+          "$ref": "./entityTypeSourceDatabaseJoin.json"
+        }
+      }
+    }
+  ]
+}

--- a/src/main/resources/swagger.api/schemas/entityTypeSourceDatabaseJoin.json
+++ b/src/main/resources/swagger.api/schemas/entityTypeSourceDatabaseJoin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "Entity Type Source Join",
-  "description": "Definition indicating how an entity type source can be joined",
+  "title": "Entity Type DB Source Join",
+  "description": "[Deprecated for use in definitions; you should likely create simple wrapper entity types and join those] Object describing how this DB view/table should be joined to another",
   "type": "object",
   "properties": {
     "type": {
@@ -17,8 +17,5 @@
       "type": "string"
     }
   },
-  "required": [
-    "type",
-    "joinTo"
-  ]
+  "required": ["type", "joinTo"]
 }

--- a/src/main/resources/swagger.api/schemas/entityTypeSourceDatabaseJoin.json
+++ b/src/main/resources/swagger.api/schemas/entityTypeSourceDatabaseJoin.json
@@ -17,5 +17,5 @@
       "type": "string"
     }
   },
-  "required": ["type", "joinTo"]
+  "required": ["type"]
 }

--- a/src/main/resources/swagger.api/schemas/entityTypeSourceEntityType.json
+++ b/src/main/resources/swagger.api/schemas/entityTypeSourceEntityType.json
@@ -22,6 +22,9 @@
           "description": "If joining, field of the new entity type that will be joined to the source entity type",
           "type": "string"
         },
+        "overrideJoinDirection": {
+          "$ref": "./field-joins/joinDirection.json"
+        },
         "useIdColumns": {
           "description": "Whether to use the idColumns of this source as idColumns for the enclosing entity type",
           "type": "boolean"

--- a/src/main/resources/swagger.api/schemas/entityTypeSourceEntityType.json
+++ b/src/main/resources/swagger.api/schemas/entityTypeSourceEntityType.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Entity Type — Entity Type Source",
+  "description": "Definition for an entity type source referring to another entity type",
+  "allOf": [
+    {
+      "$ref": "./entityTypeSource.json"
+    },
+    {
+      "type": "object",
+      "properties": {
+        "sourceField": {
+          "description": "If joining, fully qualified field of the source entity type that targetId/targetField will join to",
+          "type": "string"
+        },
+        "targetId": {
+          "description": "ID of the entity type newly included with this source",
+          "type": "string",
+          "format": "uuid"
+        },
+        "targetField": {
+          "description": "If joining, field of the new entity type that will be joined to the source entity type",
+          "type": "string"
+        },
+        "useIdColumns": {
+          "description": "Whether to use the idColumns of this source as idColumns for the enclosing entity type",
+          "type": "boolean"
+        },
+        "essentialOnly": {
+          "description": "Indicates that only critical columns for core functionality should be inherited, excluding non-essential columns",
+          "type": "boolean"
+        }
+      },
+      "required": ["targetId"]
+    }
+  ]
+}

--- a/src/main/resources/swagger.api/schemas/field-joins/join.json
+++ b/src/main/resources/swagger.api/schemas/field-joins/join.json
@@ -27,12 +27,7 @@
           "description": "Type of join expression (e.g. custom, equality-simple, equality-cast-uuid)",
           "type": "string"
         },
-        "direction": {
-          "description": "Direction of the join, from the perspective of :this JOIN :target (e.g. inner, left, right)",
-          "type": "string",
-          "enum": ["inner", "left", "right", "full"],
-          "default": "inner"
-        }
+        "direction": { "$ref": "./joinDirection.json" }
       },
       "required": ["targetId", "targetField", "type"]
     }

--- a/src/main/resources/swagger.api/schemas/field-joins/join.json
+++ b/src/main/resources/swagger.api/schemas/field-joins/join.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Definition of a possible field join",
+  "description": "A listing of a way for a field to join to another",
+  "allOf": [
+    {
+      "type": "object",
+      "discriminator": {
+        "propertyName": "type",
+        "mapping": {
+          "custom": "#/components/schemas/joinCustom",
+          "equality-simple": "#/components/schemas/joinEqualitySimple",
+          "equality-cast-uuid": "#/components/schemas/joinEqualityCastUUID"
+        }
+      },
+      "properties": {
+        "targetId": {
+          "description": "The ID of the target entity type",
+          "type": "string",
+          "format": "uuid"
+        },
+        "targetField": {
+          "description": "The field on the target entity type",
+          "type": "string"
+        },
+        "type": {
+          "description": "Type of join expression (e.g. custom, equality-simple, equality-cast-uuid)",
+          "type": "string"
+        },
+        "direction": {
+          "description": "Direction of the join, from the perspective of :this JOIN :target (e.g. inner, left, right)",
+          "type": "string",
+          "enum": ["inner", "left", "right", "full"],
+          "default": "inner"
+        }
+      },
+      "required": ["targetId", "targetField", "type"]
+    }
+  ]
+}

--- a/src/main/resources/swagger.api/schemas/field-joins/joinCustom.json
+++ b/src/main/resources/swagger.api/schemas/field-joins/joinCustom.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Custom SQL join",
+  "description": "A join that connects one field to another using a custom SQL expression. Primarily for development purposes; a custom join should likely be created instead if this is used the same way in multiple locations (deprecation warning is to encourage this by developers)",
+  "deprecated": true,
+  "allOf": [
+    {
+      "$ref": "./join.json"
+    },
+    {
+      "type": "object",
+      "properties": {
+        "sql": {
+          "description": "Raw SQL to join the columns (use :this and :that to refer to this and target columns, respectively)",
+          "type": "string"
+        }
+      },
+      "required": ["sql"]
+    }
+  ]
+}

--- a/src/main/resources/swagger.api/schemas/field-joins/joinDirection.json
+++ b/src/main/resources/swagger.api/schemas/field-joins/joinDirection.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Direction of the join, from the perspective of :this JOIN :target (e.g. inner, left, right)",
+  "type": "string",
+  "enum": ["inner", "left", "right", "full"],
+  "default": "inner"
+}

--- a/src/main/resources/swagger.api/schemas/field-joins/joinDirection.json
+++ b/src/main/resources/swagger.api/schemas/field-joins/joinDirection.json
@@ -2,6 +2,5 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "Direction of the join, from the perspective of :this JOIN :target (e.g. inner, left, right)",
   "type": "string",
-  "enum": ["inner", "left", "right", "full"],
-  "default": "inner"
+  "enum": ["inner", "left", "right", "full"]
 }

--- a/src/main/resources/swagger.api/schemas/field-joins/joinEqualityCastUUID.json
+++ b/src/main/resources/swagger.api/schemas/field-joins/joinEqualityCastUUID.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Casted UUID equality join",
+  "description": "[:this::uuid = :that::uuid] A join that connects one field to another using a simple = with explicit UUID casts",
+  "allOf": [
+    {
+      "$ref": "./join.json"
+    }
+  ]
+}

--- a/src/main/resources/swagger.api/schemas/field-joins/joinEqualitySimple.json
+++ b/src/main/resources/swagger.api/schemas/field-joins/joinEqualitySimple.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Simple equality join",
+  "description": "[:this = :that] A join that connects one field to another using a simple = expression",
+  "allOf": [
+    {
+      "$ref": "./join.json"
+    }
+  ]
+}


### PR DESCRIPTION
This PR creates a new join model which reinforces the idea of simple entity types each representing 1 DB source being joined together in arbitrary ways by higher-order entity types. This is accomplished by using a new set of pre-defined join types as part of column definitions themselves, _enabling entity types to know how to join with each other, rather than requiring higher-order entities to explicitly specify raw SQL every time_.

## What does that actually mean though??

### Simple entities

Column definitions will now describe what other columns they can join to. For example, in the user's entity type:

```json5
{
  name: 'group_id',
  sourceAlias: 'user',
  dataType: {
    dataType: 'rangedUUIDType',
  },
  isIdColumn: false,
  queryable: true,
  visibleByDefault: false,
  valueGetter: ":sourceAlias.jsonb->>'patronGroup'",
  joinsTo: [
    {
      targetId: '00000000-0000-0000-0000-groups-entity-type-id',
      targetField: 'id',
      type: 'equality-cast-uuid',
      direction: 'left',
    },
  ],
}
```

There is a set of predefined `type`s (this one compares to UUIDs after casting, i.e. `:this::uuid = :that::uuid`), in addition to one which allows custom SQL, similar to our previous join conditions.

These `joinsTo` definitions can go either side of the relationship (although IMO it should go on the child side, e.g. `user.group_id -> group.id` rather than `group.id -> user.group_id`). Things like the direction will automatically be handled as expected.

### Entity sources

Nesting all the way down 😎. Composites can point to composites can point to composites can point to composites can..., even with reused alias names, so we don't have to worry about any conflicts as our entity type trees grow. 

Now, rather than defining the join conditions for `entity-type` sources, we just specify the fields we want to link:

```json5
sources: [
  { type: 'entity-type', alias: 'users', targetId: 'users-entity-type-id' },
  {
    type: 'entity-type',
    alias: 'groups',
    // sourceField is intelligently searched for in the other source(s), and join configuration is stored on the field itself.
    // This prevents composite entity types from having to care at all about the DB tables/names below;
    //   all that matters is fields, which I feel _much_ more comfortable considering part of a simple's API
    sourceField: 'users.patron_group_id',
    targetId: 'groups-entity-type-id',
    targetField: 'id' // relative to the target entity type
}
```