### PR TITLE
MODFQMMGR-780 Remove the "root" ET property

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 4.0.0 (In development)
+- Remove the `root` property from EntityType definitions ([MODFQMMGR-780](https://folio-org.atlassian.net/browse/MODFQMMGR-780))
+- Add support for custom entity types ([FQTM-12](https://folio-org.atlassian.net/browse/FQTM-12), [MODFQMMGR-632](https://folio-org.atlassian.net/browse/MODFQMMGR-632))
+
 ## 3.1.1
 - Add MAX_SIZE_EXCEEDED query status ([MODFQMMGR-723](https://folio-org.atlassian.net/browse/MODFQMMGR-723))
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <groupId>org.folio</groupId>
   <artifactId>folio-query-tool-metadata</artifactId>
-  <version>3.2.0-SNAPSHOT</version>
+  <version>4.0.0-SNAPSHOT</version>
   <name>folio-query-tool-metadata</name>
   <description>This is a library (jar) that provides the SPI for used by the Query tool and must be implemented by a
     data provider,

--- a/src/main/resources/swagger.api/queryTool.yaml
+++ b/src/main/resources/swagger.api/queryTool.yaml
@@ -23,7 +23,6 @@ paths:
                 id: 0cb79a4c-f7eb-4941-a104-745224ae0292
                 name: item_details
                 private: false
-                root: true
                 columns: []
               schema:
                 $ref: '#/components/schemas/entityType'

--- a/src/main/resources/swagger.api/schemas/entityType.json
+++ b/src/main/resources/swagger.api/schemas/entityType.json
@@ -21,10 +21,6 @@
         "description": "The identifier used for a localized label/name for this entity.",
         "type": "string"
       },
-      "root": {
-        "description": "Indicates if this is a root entity (true) or derived entity (false)",
-        "type": "boolean"
-      },
       "private": {
         "description": "This flag denotes whether the entity type is private or not. Private entity types cannot be accessed by users for querying.",
         "type": "boolean"
@@ -102,7 +98,6 @@
     "required": [
       "id",
       "name",
-      "root",
       "private"
     ],
     "additionalProperties": true


### PR DESCRIPTION
This property is unused. This is a breaking change, so this commit also does a major version bump on the library