### PR TITLE
Refactor FQM's approach to custom field configuration in entity types

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -234,6 +234,8 @@
                 ,numberType,
                 ,rangedUUIDType,
                 ,stringUUIDType,
+                ,customFieldType,
+                ,customFieldMetadata,
                 ,nestedObjectProperty,
                 ,valueWithLabel,
                 ,valueSourceApi,

--- a/src/main/resources/swagger.api/queryTool.yaml
+++ b/src/main/resources/swagger.api/queryTool.yaml
@@ -499,6 +499,10 @@ components:
       $ref: schemas/entityDataType.json#/ArrayType
     jsonbArrayType:
       $ref: schemas/entityDataType.json#/JsonbArrayType
+    customFieldMetadata:
+      $ref: schemas/entityDataType.json#/CustomFieldMetadata
+    customFieldType:
+      $ref: schemas/entityDataType.json#/CustomFieldType
     entityTypeDefaultSort:
       $ref: schemas/entityTypeDefaultSort.json
     errors:

--- a/src/main/resources/swagger.api/schemas/entityDataType.json
+++ b/src/main/resources/swagger.api/schemas/entityDataType.json
@@ -164,5 +164,36 @@
         "$ref": "#/ArrayTypeContainer"
       }
     ]
+  },
+  "CustomFieldMetadata": {
+    "type": "object",
+    "properties": {
+      "configurationView": {
+        "description": "Name of the database view containing custom field configuration metadata (field names, possible values, etc.)",
+        "type": "string"
+      },
+      "dataExtractionPath": {
+        "description": "Extraction path for retrieving data for this set of custom fields",
+        "type": "string"
+      }
+    },
+    "required": ["configurationView", "dataExtractionPath"]
+  },
+  "CustomFieldType": {
+    "description": "Special datatype for custom fields defined in https://folio-org.atlassian.net/browse/MODFQMMGR-653",
+    "allOf": [
+      {
+        "$ref": "#/EntityDataType"
+      },
+      {
+        "type": "object",
+        "properties": {
+          "customFieldMetadata": {
+            "$ref": "#/CustomFieldMetadata"
+          }
+        },
+        "required": ["customFieldMetadata"]
+      }
+    ]
   }
 }

--- a/src/main/resources/swagger.api/schemas/entityTypeSourceEntityType.json
+++ b/src/main/resources/swagger.api/schemas/entityTypeSourceEntityType.json
@@ -32,6 +32,11 @@
         "essentialOnly": {
           "description": "Indicates that only critical columns for core functionality should be inherited, excluding non-essential columns",
           "type": "boolean"
+        },
+        "inheritCustomFields": {
+          "description": "Whether to inherit custom fields from this source. If false, only core fields will be inherited.",
+          "type": "boolean",
+          "default": true
         }
       },
       "required": ["targetId"]


### PR DESCRIPTION
## Purpose
Add new properties required for [MODFQMMGR-653](https://folio-org.atlassian.net/browse/MODFQMMGR-653) (custom field metadata + `inheritCustomFields` property for EntityTypeSources)

Here's an example of how a custom field column will look after these changes:
```
{
    "name": "user_custom_fields", // encompasses all custom fields defined in the src_user_custom_fields view
    "essential": true,
    "queryable": true,
    "visibleByDefault": false,
    "dataType": {
      "dataType": "customFieldType",
      "customFieldMetadata": {
        "configurationView": "src_user_custom_fields",
        "dataExtractionPath": ":user.jsonb -> 'customFields'"
      }
    }
}
```
