### PR TITLE
[FQTM-24] Add 'marcType' datatype to support querying MARC data

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -235,7 +235,7 @@
                 ,numberType,
                 ,rangedUUIDType,
                 ,stringUUIDType,
-                ,marcDataType,
+                ,marcType,
                 ,customFieldType,
                 ,customFieldMetadata,
                 ,nestedObjectProperty,

--- a/pom.xml
+++ b/pom.xml
@@ -235,6 +235,7 @@
                 ,numberType,
                 ,rangedUUIDType,
                 ,stringUUIDType,
+                ,marcDataType,
                 ,customFieldType,
                 ,customFieldMetadata,
                 ,nestedObjectProperty,

--- a/src/main/resources/swagger.api/queryTool.yaml
+++ b/src/main/resources/swagger.api/queryTool.yaml
@@ -525,8 +525,8 @@ components:
       $ref: schemas/entityDataType.json#/CustomFieldMetadata
     customFieldType:
       $ref: schemas/entityDataType.json#/CustomFieldType
-    marcDataType:
-      $ref: schemas/entityDataType.json#/MarcDataType
+    marcType:
+      $ref: schemas/entityDataType.json#/MarcType
     entityTypeDefaultSort:
       $ref: schemas/entityTypeDefaultSort.json
     error:

--- a/src/main/resources/swagger.api/queryTool.yaml
+++ b/src/main/resources/swagger.api/queryTool.yaml
@@ -525,6 +525,8 @@ components:
       $ref: schemas/entityDataType.json#/CustomFieldMetadata
     customFieldType:
       $ref: schemas/entityDataType.json#/CustomFieldType
+    marcDataType:
+      $ref: schemas/entityDataType.json#/MarcDataType
     entityTypeDefaultSort:
       $ref: schemas/entityTypeDefaultSort.json
     error:

--- a/src/main/resources/swagger.api/schemas/entityDataType.json
+++ b/src/main/resources/swagger.api/schemas/entityDataType.json
@@ -85,6 +85,14 @@
       }
     ]
   },
+  "MarcDataType": {
+    "description": "Entity field type representing MARC data",
+    "allOf": [
+      {
+        "$ref": "entityDataType.json#/EntityDataType"
+      }
+    ]
+  },
   "EnumType": {
     "description": "Entity field type defined in https://issues.folio.org/browse/UIPQB-11",
     "allOf": [

--- a/src/main/resources/swagger.api/schemas/entityDataType.json
+++ b/src/main/resources/swagger.api/schemas/entityDataType.json
@@ -85,7 +85,7 @@
       }
     ]
   },
-  "MarcDataType": {
+  "MarcType": {
     "description": "Entity field type representing MARC data",
     "allOf": [
       {


### PR DESCRIPTION
## Purpose
[FQTM-24](https://folio-org.atlassian.net/browse/FQTM-24): Add 'marcType' datatype to support querying MARC data
