### PR TITLE
MODFQMMGR-1081 Add availableOperators property for fields

### DIFF
--- a/src/main/resources/swagger.api/schemas/field.json
+++ b/src/main/resources/swagger.api/schemas/field.json
@@ -76,6 +76,13 @@
     },
     "defaultValue": {
       "description": "Default value for this field if none is provided"
+    },
+    "availableOperators": {
+      "description": "The operators available for this field when building queries. When set, this overrides the default operator set for the data type. When absent, the default operators for the data type are used.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     }
   },
   "required": ["name", "dataType"]


### PR DESCRIPTION
This property allows us to override the default operators available for fields in the query builder UI.